### PR TITLE
Add MiniMongo support for find cursor limit, skip and sort methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,16 @@ class Post < MiniMongo::Base
   maps :posts
 end
 
+### Examples
 # Post.insert({:author => "Chuck Norris"})
 # => #<Post:0x007fe5240f42c0 @id="5016af53bda74305f1000002", @author="Chuck Norris">
 
 # Post.find("id" => "5016af53bda74305f1000002")
 # => #<Post:0x007fe5240cc360 @id="5016af53bda74305f1000002", @author="Chuck Norris">
+#
+# Find cursor method sort, limit and skip support
+# Post.find({"id" => "5016af53bda74305f1000002"}, {:limit => 1})
+# => #<Post:0x007fe5240cc363 @id="5016af53bda74305f1000003", @author="Bruce Lee">
 #
 # Post.update("5016af53bda74305f1000002", "author" => "chuck norris")
 # => #<Post:0x007fdc7c171c80 @author="chuck norris", @id="5016af53bda74305f1000002">

--- a/lib/mini_mongo/mapper.rb
+++ b/lib/mini_mongo/mapper.rb
@@ -8,12 +8,15 @@ module MiniMongo
     end
 
     module ClassMethods
-      def find(attrs={})
+      def find(attrs={}, opts={})
         attrs["_id"] = BSON::ObjectId(attrs["id"]) if attrs["id"]
         attrs.delete("id")
-        docs = self.collection.find(attrs).to_a
+        docs = self.collection.find(attrs, opts).to_a
         if docs.empty?
-          raise DocumentNotFound, "Couldn't find #{self.collection_name.capitalize}, with #{attrs.to_a.collect {|p| p.join(' = ')}.join(', ')}"
+          raise DocumentNotFound,
+          "Couldn't find #{self.collection_name.capitalize}, "
+          "with #{attrs.to_a.collect {|p| p.join(' = ')}.join(', ')}"
+          "and #{opts.to_a.collect {|p| p.join(' = ')}.join(', ')}"
         else
           result = []
           docs.each do |doc|

--- a/lib/mini_mongo/version.rb
+++ b/lib/mini_mongo/version.rb
@@ -1,3 +1,3 @@
 module MiniMongo
-  VERSION = "0.0.4"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Add MiniMongo support for find cursor sort, limit, and skip MongoDB collection methods.
ref: http://docs.mongodb.org/manual/reference/method/db.collection.find/

README.md **Usage** section updated to reflect these changes.
